### PR TITLE
Calendar: Fix translatability of buttons list

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -222,7 +222,6 @@
         <item>Week</item>
         <item>Month</item>
         <item>Agenda</item>
-        <item>Year</item>
     </string-array>
 
     <!-- Experimental options for skipping reminders. [CHAR LIMIT = 37] -->

--- a/res/values/cm_arrays.xml
+++ b/res/values/cm_arrays.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-     Copyright (C) 2012-2014 The CyanogenMod Project
+     Copyright (C) 2012-2015 The CyanogenMod Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -45,5 +45,14 @@
         <item>3</item>
         <item>4</item>
         <item>1</item>
+    </string-array>
+
+    <!-- Strings for buttons in drop down menu -->
+    <string-array name="buttons_list_cm" translatable="false">
+        <item>@string/buttons_list_0</item>
+        <item>@string/buttons_list_1</item>
+        <item>@string/buttons_list_2</item>
+        <item>@string/buttons_list_3</item>
+        <item>@string/buttons_list_4</item>
     </string-array>
 </resources>

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -60,4 +60,11 @@
     <!-- Toast message displayed when ics file to share an event can't be generated -->
     <string name="error_generating_ics">Problems encountered while sharing event</string>
     <string name="share_label">Share</string>
+
+    <!-- Strings for buttons in drop down menu -->
+    <string name="buttons_list_0">Day</string>
+    <string name="buttons_list_1">Week</string>
+    <string name="buttons_list_2">Month</string>
+    <string name="buttons_list_3">Agenda</string>
+    <string name="buttons_list_4">Year</string>
 </resources>

--- a/src/com/android/calendar/AllInOneActivity.java
+++ b/src/com/android/calendar/AllInOneActivity.java
@@ -111,7 +111,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
     private static final int HANDLER_KEY = 0;
 
     // Indices of buttons for the drop down menu (tabs replacement)
-    // Must match the strings in the array buttons_list in arrays.xml and the
+    // Must match the strings in the array buttons_list_cm in cm_arrays.xml and the
     // OnNavigationListener
     private static final int BUTTON_DAY_INDEX = 0;
     private static final int BUTTON_WEEK_INDEX = 1;

--- a/src/com/android/calendar/CalendarViewAdapter.java
+++ b/src/com/android/calendar/CalendarViewAdapter.java
@@ -110,7 +110,7 @@ public class CalendarViewAdapter extends BaseAdapter {
         mShowDate = showDate;
 
         // Initialize
-        mButtonNames = context.getResources().getStringArray(R.array.buttons_list);
+        mButtonNames = context.getResources().getStringArray(R.array.buttons_list_cm);
         mInflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
         mStringBuilder = new StringBuilder(50);
         mFormatter = new Formatter(mStringBuilder, Locale.getDefault());


### PR DESCRIPTION
* Revert change to AOSP array, move to new array
* Convert entries to string references, set as untranslatable

Change-Id: I490a78aa81e826835044a03a0bb4f2578644d7ba